### PR TITLE
Resolve #4 Updated text aligned:left on the span

### DIFF
--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -74,10 +74,13 @@ export default function Layout({ children }) {
               <Link href={"/output"}>
                 <button
                   className={
-                    "group flex w-full items-center justify-between space-x-2 px-2"
+                    "group flex w-full items-center justify-start space-x-2 px-2"
                   }
                 >
-                  <span className={"text-slate-400 group-hover:text-slate-200"}>
+                  <span 
+                    className={"text-slate-400 group-hover:text-slate-200"}
+                    style={{ display: 'block', textAlign: 'left' }}
+                  >
                     Solution Details
                   </span>
                   <ArrowSmallRightIcon


### PR DESCRIPTION
**Summary**
Added left text aligned style on the span element. So that the Solution Details will stay the same on the smaller screen.

**Changes**
- Added left text alignment style on the span element.

**Related Issues**
Resolves issue #4 