### PR TITLE
Check for undefined before accessing output history

### DIFF
--- a/utils/ProjectDataReducer.js
+++ b/utils/ProjectDataReducer.js
@@ -260,7 +260,7 @@ function innerProjectDataReducer(state, action) {
         current_selected_output_id: new_output_id,
         unsaved_changes: false,
         locked_tasks: [],
-        output_history: state.output_history.length
+        output_history: (state.output_history ?? []).length > 0
           ? [...state.output_history, new_output_state]
           : [new_output_state],
       };


### PR DESCRIPTION
This should fix the error we've been experiencing on the site. The problem was that the state's `output_history` field is not set in certain cases before the solution is generated.