### PR TITLE
Ignore unsupported ESLint major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "eslint"
+        update-types:
+          - "version-update:semver-major"
     assignees:
       - "ozgurakgun"
    # groups:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5499,10 +5499,11 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }


### PR DESCRIPTION
## Summary
- keep ESLint on the latest valid 9.x line because the current Next ESLint stack depends on plugins whose latest releases do not peer-support ESLint 10
- add a Dependabot ignore for ESLint semver-major updates to avoid repeat broken PRs
- refresh the lockfile after reinstalling the valid ESLint 9 tree

## Verification
- npm run lint
- npm run build
- npm audit --audit-level=moderate
- npm ls eslint eslint-plugin-react eslint-plugin-import eslint-plugin-jsx-a11y --depth=3