### PR TITLE
Fix sparse ids in solver payloads

### DIFF
--- a/utils/ProjectDataReducer.js
+++ b/utils/ProjectDataReducer.js
@@ -1,4 +1,5 @@
 import findNextId from "./max-id";
+import { convertSolutionToProjectIds } from "./model";
 
 const ACTIONS_NOT_ELICITING_UNSAVED_CHANGES = [
   "NEW_PROJECT",
@@ -251,6 +252,7 @@ function innerProjectDataReducer(state, action) {
           categories: [...state.categories],
           locked_tasks: state.locked_tasks ? [...state.locked_tasks] : [],
         },
+        solverMappings: action.solverMappings,
         output_id: new_output_id,
         date: Date.now(),
       };
@@ -278,7 +280,10 @@ function innerProjectDataReducer(state, action) {
         action.output.solution.length > 0
       ) {
         hist_obj.status = "ok";
-        hist_obj.solution = action.output.solution[0];
+        hist_obj.solution = convertSolutionToProjectIds(
+          action.output.solution[0],
+          hist_obj.solverMappings,
+        );
       } else {
         hist_obj.status = action.output.status;
       }

--- a/utils/generation-handler.js
+++ b/utils/generation-handler.js
@@ -1,8 +1,15 @@
 import axios from "axios";
-import { convertInput, ESSENCE_MODEL, SUBMIT_URL } from "./model";
+import {
+  convertInput,
+  createSolverMappings,
+  ESSENCE_MODEL,
+  SUBMIT_URL,
+} from "./model";
 
 export const handleGenerate = async (e, projectData, dispatch, router) => {
   e.preventDefault();
+
+  const solverMappings = createSolverMappings(projectData);
 
   const res = await axios.post(
     SUBMIT_URL,
@@ -10,7 +17,7 @@ export const handleGenerate = async (e, projectData, dispatch, router) => {
       appName: "task-allocation",
       solver: "chuffed",
       model: ESSENCE_MODEL,
-      data: JSON.stringify(convertInput(projectData)),
+      data: JSON.stringify(convertInput(projectData, solverMappings)),
       conjureOptions: ["--solver-options='-t 30000'"], // use a time limit of 10 seconds
     },
     {
@@ -23,5 +30,6 @@ export const handleGenerate = async (e, projectData, dispatch, router) => {
   dispatch({
     type: "WAIT_OUTPUT",
     job_id: res.data.jobid,
+    solverMappings,
   });
 };

--- a/utils/model.js
+++ b/utils/model.js
@@ -1,18 +1,55 @@
-export function convertInput(projectData) {
+export function createSolverMappings(projectData) {
+  const taskToSolver = createDenseIdMap(projectData.tasks);
+  const userToSolver = createDenseIdMap(projectData.users);
+  const categoryToSolver = createDenseIdMap(projectData.categories);
+
+  return {
+    taskToSolver,
+    solverToTask: invertMap(taskToSolver),
+    userToSolver,
+    solverToUser: invertMap(userToSolver),
+    categoryToSolver,
+    solverToCategory: invertMap(categoryToSolver),
+  };
+}
+
+function createDenseIdMap(items) {
+  return items.reduce((acc, item, index) => {
+    acc[item.id] = index + 1;
+    return acc;
+  }, {});
+}
+
+function invertMap(map) {
+  return Object.entries(map).reduce((acc, [id, solverId]) => {
+    acc[solverId] = parseInt(id);
+    return acc;
+  }, {});
+}
+
+export function convertInput(
+  projectData,
+  mappings = createSolverMappings(projectData),
+) {
   return {
     nb_tasks: projectData.tasks.length,
     nb_users: projectData.users.length,
     nb_categories: projectData.categories.length,
     tasks: projectData.tasks.reduce((acc, cur) => {
-      acc[cur.id + 1] = { category: cur.category + 1, weight: cur.weight };
+      acc[mappings.taskToSolver[cur.id]] = {
+        category: mappings.categoryToSolver[cur.category],
+        weight: cur.weight,
+      };
       return acc;
     }, {}),
     users: projectData.users.reduce((acc, cur) => {
-      acc[cur.id + 1] = {
-        forbidden_tasks: cur.task_blacklist.map((x) => x + 1),
-        task_preferences: cur.preferences.map((x) => x + 1),
+      acc[mappings.userToSolver[cur.id]] = {
+        forbidden_tasks: cur.task_blacklist.map(
+          (x) => mappings.taskToSolver[x],
+        ),
+        task_preferences: cur.preferences.map((x) => mappings.taskToSolver[x]),
         category_percentages: cur.categories.reduce((catAcc, catCur) => {
-          catAcc[catCur.id + 1] = catCur.percentage;
+          catAcc[mappings.categoryToSolver[catCur.id]] = catCur.percentage;
           return catAcc;
         }, {}),
       };
@@ -20,12 +57,35 @@ export function convertInput(projectData) {
     }, {}),
     partial_assignment: projectData.locked_tasks
       ? projectData.locked_tasks.reduce((acc, cur) => {
-          acc[cur + 1] = projectData.output_history.find(
+          const uiAssignment = projectData.output_history.find(
             (oh) => oh.output_id === projectData.current_selected_output_id,
-          ).solution.assignment[cur + 1];
+          ).solution.assignment;
+          const userId = parseInt(uiAssignment[cur + 1]) - 1;
+
+          acc[mappings.taskToSolver[cur]] = mappings.userToSolver[userId];
           return acc;
         }, {})
       : [],
+  };
+}
+
+export function convertSolutionToProjectIds(solution, mappings) {
+  if (!solution.assignment) {
+    return solution;
+  }
+
+  return {
+    ...solution,
+    assignment: Object.entries(solution.assignment).reduce(
+      (acc, [solverTaskId, solverUserId]) => {
+        const taskId = mappings.solverToTask[solverTaskId];
+        const userId = mappings.solverToUser[solverUserId];
+
+        acc[taskId + 1] = userId + 1;
+        return acc;
+      },
+      {},
+    ),
   };
 }
 


### PR DESCRIPTION
## Summary
- build dense solver id mappings for tasks, users, and categories before submitting data
- remap task references in preferences, forbidden tasks, and partial assignments
- convert solver assignment output back to project ids before storing it

## Verification
- npm run lint
- npm run build